### PR TITLE
Add support for lcov.info files

### DIFF
--- a/lib/lcov-parser.coffee
+++ b/lib/lcov-parser.coffee
@@ -1,0 +1,6 @@
+parse = require "lcov-parse"
+
+module.exports =
+class LcovParser
+  constructor: (path) ->
+    @lcovData = null

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "fs-plus": "2.3.1",
-    "tablesort": "2.0.0"
+    "tablesort": "2.0.0",
+    "lcov-parse": "0.0.8"
   }
 }


### PR DESCRIPTION
This PR will add support for `lcov.info` files. The current functionallity of parsing the simplecov.json will be dropped because simplecov can also output lcov files.

With this pull request a lot of new coverage tools are going to be supported.
### Tasks
- [ ] Lcov Parser
- [ ] PanelView
  - [ ] Change columns to _File, Coverage, Relevant lines, Covered, Missed, Hits/Line_
  - [ ] Fix sorting
- [ ] Configuration
  - [ ] Default `coverageFilePath` to: "coverage/lcov.info"
- [ ] Readme
  - [ ] Document supported coverage tools

Closes https://github.com/philipgiuliani/coverage/issues/9
